### PR TITLE
fix(events/list): Allow max results param, default 10000

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -253,7 +253,7 @@ module SpecHelper
   end
 
   def mock_list_events
-    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users/foo@bar.com/calendar/calendarView?startDateTime=2020-01-01T00:00:00-00:00&endDateTime=2020-06-01T00:00:00-00:00").to_return(mock_event_query_json)
+    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users/foo@bar.com/calendar/calendarView?startDateTime=2020-01-01T00:00:00-00:00&endDateTime=2020-06-01T00:00:00-00:00&top=10000").to_return(mock_event_query_json)
   end
 
   def mock_batch_list_events

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -253,7 +253,7 @@ module SpecHelper
   end
 
   def mock_list_events
-    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users/foo@bar.com/calendar/calendarView?startDateTime=2020-01-01T00:00:00-00:00&endDateTime=2020-06-01T00:00:00-00:00&top=10000").to_return(mock_event_query_json)
+    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users/foo@bar.com/calendar/calendarView?startDateTime=2020-01-01T00:00:00-00:00&endDateTime=2020-06-01T00:00:00-00:00&$top=10000").to_return(mock_event_query_json)
   end
 
   def mock_batch_list_events

--- a/src/events.cr
+++ b/src/events.cr
@@ -138,7 +138,8 @@ module Office365::Events
     calendar_id : String? = nil,
     period_start : Time = Time.local.at_beginning_of_day,
     period_end : Time? = nil,
-    ical_uid : String? = nil
+    ical_uid : String? = nil,
+    top : UInt16? = 10000
   )
     end_period = period_end || period_start + 6.months
 
@@ -157,6 +158,6 @@ module Office365::Events
 
     ical_filter = HTTP::Params.parse(ical_uid.presence ? "$filter=iCalUId eq '#{ical_uid}'" : "").to_s
     ical_filter = "&#{ical_filter}" unless ical_filter.empty?
-    "#{endpoint}?startDateTime=#{period_start.to_s("%FT%T-00:00")}&endDateTime=#{end_period.not_nil!.to_s("%FT%T-00:00")}#{ical_filter}"
+    "#{endpoint}?startDateTime=#{period_start.to_s("%FT%T-00:00")}&endDateTime=#{end_period.not_nil!.to_s("%FT%T-00:00")}#{ical_filter}&$top=${top}"
   end
 end

--- a/src/events.cr
+++ b/src/events.cr
@@ -139,7 +139,7 @@ module Office365::Events
     period_start : Time = Time.local.at_beginning_of_day,
     period_end : Time? = nil,
     ical_uid : String? = nil,
-    top : UInt16? = 10000
+    top : Int? = 10000
   )
     end_period = period_end || period_start + 6.months
 

--- a/src/events.cr
+++ b/src/events.cr
@@ -158,6 +158,8 @@ module Office365::Events
 
     ical_filter = HTTP::Params.parse(ical_uid.presence ? "$filter=iCalUId eq '#{ical_uid}'" : "").to_s
     ical_filter = "&#{ical_filter}" unless ical_filter.empty?
-    "#{endpoint}?startDateTime=#{period_start.to_s("%FT%T-00:00")}&endDateTime=#{end_period.not_nil!.to_s("%FT%T-00:00")}#{ical_filter}&$top=#{top}"
+    path = "#{endpoint}?startDateTime=#{period_start.to_s("%FT%T-00:00")}&endDateTime=#{end_period.not_nil!.to_s("%FT%T-00:00")}#{ical_filter}"
+    path += "&$top=#{top}" unless top.nil?
+    path
   end
 end

--- a/src/events.cr
+++ b/src/events.cr
@@ -139,7 +139,7 @@ module Office365::Events
     period_start : Time = Time.local.at_beginning_of_day,
     period_end : Time? = nil,
     ical_uid : String? = nil,
-    top : Int? = 10000
+    top : Int32? = 10000
   )
     end_period = period_end || period_start + 6.months
 

--- a/src/events.cr
+++ b/src/events.cr
@@ -158,6 +158,6 @@ module Office365::Events
 
     ical_filter = HTTP::Params.parse(ical_uid.presence ? "$filter=iCalUId eq '#{ical_uid}'" : "").to_s
     ical_filter = "&#{ical_filter}" unless ical_filter.empty?
-    "#{endpoint}?startDateTime=#{period_start.to_s("%FT%T-00:00")}&endDateTime=#{end_period.not_nil!.to_s("%FT%T-00:00")}#{ical_filter}&$top=${top}"
+    "#{endpoint}?startDateTime=#{period_start.to_s("%FT%T-00:00")}&endDateTime=#{end_period.not_nil!.to_s("%FT%T-00:00")}#{ical_filter}&$top=#{top}"
   end
 end


### PR DESCRIPTION
Currently list_events will only EVER return up to 10 events, which is a big problem that I've verified by using the place/calendar Driver in backoffice and graph api directly in Postman:

Without specifying a graph api [$top param](https://docs.microsoft.com/en-us/graph/query-parameters#top-parameter), up to 10 results are returned for listing calendar events. 
The response also has an `@odata.nextLink` value to retrieve the rest of the results (which is NOT yet implemented in this lib AFAIK):
![image](https://user-images.githubusercontent.com/10395560/114661360-7067c180-9d29-11eb-8c82-f00fa79389a6.png)

When $top is specified for the exact same request, all the events are returned
![image](https://user-images.githubusercontent.com/10395560/114661633-e1a77480-9d29-11eb-84cf-4e383a8b03e0.png)

I need an URGENT fix where the **default** `top` is >10. 1000 would be fine and I've just set 10,000 (as per old ruby o365-engine).

A less urgent FOLLOW-UP feature addition would be to allow the list_events method to optionally specify the `top` value (still with a default of 10,000)