### PR TITLE
feat(groups): default to transitiveMemberOf

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -106,7 +106,7 @@ module SpecHelper
   end
 
   def mock_groups_member_of
-    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users/#{mock_user.id}/memberOf/microsoft.graph.group?%24orderby=displayName&%24top=999")
+    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users/#{mock_user.id}/transitiveMemberOf/microsoft.graph.group?%24orderby=displayName&%24top=999")
       .to_return(mock_group_query.to_json)
   end
 

--- a/src/groups.cr
+++ b/src/groups.cr
@@ -78,8 +78,8 @@ module Office365::Groups
     UserQuery.from_json response.body
   end
 
-  # MembersOf Request, what groups a user is in
-  def groups_member_of_request(user_id : String, q : String? = nil)
+  # MemberOf Request, what groups a user is in (defaults to including nested groups)
+  def groups_member_of_request(user_id : String, q : String? = nil, transitive : Bool? = true)
     if q.presence
       filter_param = %("displayName:#{q}")
     end
@@ -93,10 +93,12 @@ module Office365::Groups
     # This is required to do searching
     headers = HTTP::Headers{"ConsistencyLevel" => "eventual"}
     headers.merge! default_headers
+    
+    member_of = transitive ? "transitiveMemberOf" : "memberOf"
 
     graph_http_request(
       request_method: "GET",
-      path: "#{USERS_BASE}/#{user_id}/memberOf/microsoft.graph.group",
+      path: "#{USERS_BASE}/#{user_id}/#{member_of}/microsoft.graph.group",
       query: query_params,
       headers: headers
     )

--- a/src/groups.cr
+++ b/src/groups.cr
@@ -93,7 +93,7 @@ module Office365::Groups
     # This is required to do searching
     headers = HTTP::Headers{"ConsistencyLevel" => "eventual"}
     headers.merge! default_headers
-    
+
     member_of = transitive ? "transitiveMemberOf" : "memberOf"
 
     graph_http_request(


### PR DESCRIPTION
Note that querying a User's Groups will now default to transitive.

But querying a Group's users will remain non-transitive, as a transitive request for this could potentially return all or most users in the organisation.