### PR TITLE
Add URI encoder and replace odd request creation with the standard one

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: office365
-version: 1.14.0
+version: 1.14.1
 
 crystal: ">= 0.36.1"
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -88,12 +88,12 @@ module SpecHelper
   end
 
   def mock_list_users
-    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users?%24filter=accountEnabled+eq+true")
+    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users?$filter=accountEnabled eq true")
       .to_return(mock_user_query.to_json)
   end
 
   def mock_list_users_with_query
-    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users?%24filter=%28id+in+%28%271234-5678-9012%27%2C+%271234-5678-5435%27%29%29")
+    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users?$filter=(id in ('1234-5678-9012', '1234-5678-5435'))")
       .to_return(mock_user_query.to_json)
   end
 
@@ -111,17 +111,17 @@ module SpecHelper
   end
 
   def mock_list_group_members
-    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/groups/1234-5678-9012/members/microsoft.graph.user?%24orderby=displayName&%24top=999")
+    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/groups/1234-5678-9012/members/microsoft.graph.user?$orderby=displayName&$top=999")
       .to_return(mock_user_query.to_json)
   end
 
   def mock_groups_member_of
-    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users/#{mock_user.id}/transitiveMemberOf/microsoft.graph.group?%24orderby=displayName&%24top=999")
+    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users/#{mock_user.id}/transitiveMemberOf/microsoft.graph.group?$orderby=displayName&$top=999")
       .to_return(mock_group_query.to_json)
   end
 
   def mock_list_groups
-    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/groups?%24filter=startswith%28displayName%2C+%27query%27%29&%24top=950")
+    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/groups?$filter=startswith(displayName, 'query')&$top=950")
       .to_return(mock_group_query.to_json)
   end
 
@@ -139,7 +139,7 @@ module SpecHelper
   end
 
   def mock_list_calendar_groups
-    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users/foo@bar.com/calendarGroups?%24top=99")
+    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users/foo@bar.com/calendarGroups?$top=99")
       .to_return(mock_calendar_group_query.to_json)
   end
 
@@ -343,7 +343,7 @@ module SpecHelper
   end
 
   def mock_list_attachments
-    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users/foo@bar.com/calendar/events/1234/attachments?%24top=100").to_return(mock_attachment_query_json)
+    WebMock.stub(:get, "https://graph.microsoft.com/v1.0/users/foo@bar.com/calendar/events/1234/attachments?$top=100").to_return(mock_attachment_query_json)
   end
 
   def mock_create_attachment

--- a/src/client.cr
+++ b/src/client.cr
@@ -102,7 +102,9 @@ module Office365
         path = "#{path}?#{query.join('&') { |k, v| HTTP::Params.parse("#{k}=#{v}") }}"
       end
 
-      HTTP::Request.new(request_method, path, headers, data)
+      # Decode all of the encoded values that might've been accidentally or purposely encoded.
+      path = URI.decode(path)
+      HTTP::Request.new(request_method, URI.encode(path), headers, data)
     end
 
     def graph_request(http_request : HTTP::Request)
@@ -120,7 +122,7 @@ module Office365
     def default_headers
       HTTP::Headers{
         "Authorization" => "Bearer #{access_token}",
-        "Content-type"  => "application/json",
+        "Content-Type"  => "application/json",
         "Prefer"        => %(IdType="ImmutableId"),
       }
     end

--- a/src/users.cr
+++ b/src/users.cr
@@ -104,7 +104,7 @@ module Office365::Users
             in {Nil, Nil}                     then ""
             end
 
-    request = HTTP::Request.new("GET", path, self.default_headers)
+    request = graph_http_request("GET", path)
     response = graph_request(request)
     list_users(response)
   end


### PR DESCRIPTION
- [x] Replace the URI encoded mock URL's.
- [x] Update the request creation to deal with the `HTTP Version Not Supported` exception.
- [x] Fix a typo in the `Content-Type` header.