### PR TITLE
feat(event): event.body default is HTML not text

### DIFF
--- a/src/models/item_body.cr
+++ b/src/models/item_body.cr
@@ -6,6 +6,6 @@ class Office365::ItemBody
   @[JSON::Field(key: "contentType")]
   property content_type : String?
 
-  def initialize(@content = "", @content_type = "text")
+  def initialize(@content = "", @content_type = "HTML")
   end
 end


### PR DESCRIPTION
**Description of the change**

Currently event body content-type is `text` by default.
A client has noticed that all events created with staff-api have their MS Teams link appended to the invite email in text as opposed to a better looking HTML:

Example 1 where the event was created with staff-api, which POSTs to MSGraph with `event.body.contentType: text`
![image](https://user-images.githubusercontent.com/10395560/160075426-0ab643f2-2f0d-4784-b446-cc8eadc85b66.png)

The developers noticed when testing is MS Graph API Explorer that if they set `event.body.contentType: HTML` that the automatically appended Teams invite link (which gets added when     `"isOnlineMeeting": true,` is part of the event POST) looks much nicer as it's HTML:

Example 2, where POST to MSG had
```
    "body": {
        "contentType": "HTML",
        "content": "Does noon work for you?"
    },
```
![image](https://user-images.githubusercontent.com/10395560/160075924-07531e89-bfad-4e26-ac27-92611f6630fc.png)

As you can see in the snippet above, the `body.content` can still be text (no need to add `<html>` tags)

The client has expressed that they require the MS Teams invite links to be in this HTML format, which is much more commonly seen and what they are accustomed to. I believe that this should be our default.

There appears to be no drawback to setting `contentType: HTML` instead of `text` since the input `content` can still be text (it automatically gets converted to HTML by MSG).

After this change, once staff-api gets updated to the new placeos/office365 shard, it's tests will need to be updated to reflect  this change: https://github.com/PlaceOS/staff-api/search?q=contenttype
