### PR TITLE
feat(calendars): add support for availabilityViewInterval

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: office365
-version: 1.14.2
+version: 1.15.0
 
 crystal: ">= 0.36.1"
 

--- a/src/calendars.cr
+++ b/src/calendars.cr
@@ -165,7 +165,8 @@ module Office365::Calendars
     response.success? ? true : false
   end
 
-  def get_availability_request(mailbox : String, mailboxes : Array(String), starts_at : Time, ends_at : Time, view_interval : Int32)
+  # default view_interval of 30mins
+  def get_availability_request(mailbox : String, mailboxes : Array(String), starts_at : Time, ends_at : Time, view_interval : Int32 = 30)
     endpoint = "#{USERS_BASE}/#{mailbox}/calendar/getSchedule"
     data = GetAvailabilityQuery.new(mailboxes, starts_at, ends_at, view_interval)
 

--- a/src/calendars.cr
+++ b/src/calendars.cr
@@ -165,9 +165,9 @@ module Office365::Calendars
     response.success? ? true : false
   end
 
-  def get_availability_request(mailbox : String, mailboxes : Array(String), starts_at : Time, ends_at : Time)
+  def get_availability_request(mailbox : String, mailboxes : Array(String), starts_at : Time, ends_at : Time, view_interval : Int32)
     endpoint = "#{USERS_BASE}/#{mailbox}/calendar/getSchedule"
-    data = GetAvailabilityQuery.new(mailboxes, starts_at, ends_at)
+    data = GetAvailabilityQuery.new(mailboxes, starts_at, ends_at, view_interval)
 
     graph_http_request(request_method: "POST", path: endpoint, data: data.to_json)
   end

--- a/src/models/availability_query.cr
+++ b/src/models/availability_query.cr
@@ -16,7 +16,10 @@ module Office365
     @[JSON::Field(key: "endTime", converter: Office365::DateTimeTimeZone)]
     property ends_at : Time
 
-    def initialize(@schedules, @starts_at, @ends_at)
+    @[JSON::Field(key: "availabilityViewInterval")]
+    property view_interval : Int32
+
+    def initialize(@schedules, @starts_at, @ends_at, @view_interval)
     end
   end
 end


### PR DESCRIPTION
**Description of the change**

Availability requests can now be made with an optional `view_interval` parameter or defaults to 30mins as specified in the Microsoft 365 [docs](https://docs.microsoft.com/en-us/graph/api/calendar-getschedule?view=graph-rest-1.0&tabs=http#request-body)

**Applicable issues**

Needed for https://github.com/PlaceOS/office365/issues/29
